### PR TITLE
Added attribute to treat png's as binary files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # Force text files to have unix eols, so Windows/Cygwin does not break them
 *.* eol=lf
+
+# Except for images because then on checkout the files have been altered.
+*.png binary


### PR DESCRIPTION
Without treating the pngs as binary the existing gitattributes file forces git to swap out crlf to lf.

Git then notices the files have changed and they are marked as such.