### PR TITLE
Use window_id/pane_id for current_pane_logging.

### DIFF
--- a/scripts/toggle_logging.sh
+++ b/scripts/toggle_logging.sh
@@ -24,7 +24,7 @@ stop_pipe_pane() {
 
 # returns a string unique to current pane
 pane_unique_id() {
-	tmux display-message -p "#{session_name}_#{window_index}_#{pane_index}"
+	tmux display-message -p "#{session_name}_#{window_id}_#{pane_id}"
 }
 
 # saving 'logging' 'not logging' status in a variable unique to pane


### PR DESCRIPTION
Prior code used window_index/pane_index which were not unique. If a
window/pane is destroyed with logging enabled and then recreated, state
in current_pane_logging will still indicate that logging is on while in
reality it is off.