### PR TITLE
Quote values for -z test.

### DIFF
--- a/scripts/shared.sh
+++ b/scripts/shared.sh
@@ -2,7 +2,7 @@ get_tmux_option() {
 	local option=$1
 	local default_value=$2
 	local option_value=$(tmux show-option -gqv "$option")
-	if [ -z $option_value ]; then
+	if [ -z "$option_value" ]; then
 		echo $default_value
 	else
 		echo $option_value


### PR DESCRIPTION
Otherwise if value is empty, you will get something like:

/usr/local/share/tmux/plugins/tmux-logging/scripts/shared.sh: line 5: [: not: binary operator expected
