### PR TITLE
Document custom settings for keybindings and logging paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This is just a convenience key binding.
 
 Keybindings could be customized with
 
-    set -g @logging_key "P" # Shift-p
+    set -g @logging-key "P" # Shift-p
     set -g @screen-capture-key "M-p" # Alt-p
     set -g @save-complete-history-key "M-P" # Alt-Shift-p
     set -g @clear-history-key "M-c" # Alt-c

--- a/README.md
+++ b/README.md
@@ -56,6 +56,21 @@ Key binding: `prefix + alt + c`
 
 This is just a convenience key binding.
 
+### Settings
+
+Keybindings could be customized with
+
+    set -g @logging_key "P" # Shift-p
+    set -g @screen-capture-key "M-p" # Alt-p
+    set -g @save-complete-history-key "M-P" # Alt-Shift-p
+    set -g @clear-history-key "M-c" # Alt-c
+
+Besides, logging locations could be customized as well.
+
+    set -g @logging-path "~" # default $HOME
+    set -g @screen-capture-path "~"
+    set -g @save-complete-history-path "~"
+
 ### Installation with [Tmux Plugin Manager](https://github.com/tmux-plugins/tpm) (recommended)
 
 Add plugin to the list of TPM plugins in `.tmux.conf`:

--- a/README.md
+++ b/README.md
@@ -67,9 +67,12 @@ Keybindings could be customized with
 
 Besides, logging locations could be customized as well.
 
-    set -g @logging-path "~" # default $HOME
-    set -g @screen-capture-path "~"
-    set -g @save-complete-history-path "~"
+    set -g @logging-path "$HOME"
+    set -g @screen-capture-path "$HOME"
+    set -g @save-complete-history-path "$HOME"
+
+**NOTE**: `$HOME` but not tilde `~` is recommended because `~` may not be expanded correctly
+in the shell script once it's quoted as `"~"`.
 
 ### Installation with [Tmux Plugin Manager](https://github.com/tmux-plugins/tpm) (recommended)
 
@@ -100,7 +103,7 @@ You should now have all `tmux-logging` key bindings defined.
 
 ### Installing `ansifilter` (recommended for OSX users)
 
-If you're on OSX, it is recommeneded to install `ansifilter`:
+If you're on OSX, it is recommended to install `ansifilter`:
 `$ brew install ansifilter`
 
 [ansifilter](http://www.andre-simon.de/doku/ansifilter/en/ansifilter.php)

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -3,7 +3,7 @@ SUPPORTED_VERSION="1.9"
 # Key binding options and defaults
 
 default_logging_key="P" # Shift-p
-logging_key=$(tmux show-option -gqv "@logging_key")
+logging_key=$(tmux show-option -gqv "@logging-key")
 logging_key=${logging_key:-$default_logging_key}
 
 default_pane_screen_capture_key="M-p" # Alt-p

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -25,6 +25,7 @@ filename_suffix="#{session_name}-#{window_index}-#{pane_index}-%Y%m%dT%H%M%S.log
 default_logging_path="$HOME"
 logging_path=$(tmux show-option -gqv "@logging-path")
 logging_path=${logging_path:-$default_logging_path}
+! [ -d "$logging_path" ] && mkdir -p "$logging_path" 2>/dev/null
 
 default_logging_filename="tmux-${filename_suffix}"
 logging_filename=$(tmux show-option -gqv "@logging-filename")
@@ -36,6 +37,7 @@ logging_full_filename="${logging_path}/${logging_filename}"
 default_screen_capture_path="$HOME"
 screen_capture_path=$(tmux show-option -gqv "@screen-capture-path")
 screen_capture_path=${screen_capture_path:-$default_screen_capture_path}
+! [ -d "$screen_capture_path" ] && mkdir -p "$screen_capture_path" 2>/dev/null
 
 default_screen_capture_filename="tmux-screen-capture-${filename_suffix}"
 screen_capture_filename=$(tmux show-option -gqv "@screen-capture-filename")
@@ -47,6 +49,7 @@ screen_capture_full_filename="${screen_capture_path}/${screen_capture_filename}"
 default_save_complete_history_path="$HOME"
 save_complete_history_path=$(tmux show-option -gqv "@save-complete-history-path")
 save_complete_history_path=${save_complete_history_path:-$default_save_complete_history_path}
+! [ -d "$save_complete_history_path" ] && mkdir -p "$save_complete_history_path" 2>/dev/null
 
 default_save_complete_history_filename="tmux-history-${filename_suffix}"
 save_complete_history_filename=$(tmux show-option -gqv "@save-complete-history-filename")


### PR DESCRIPTION
Both keybindings and logging paths could be customized by the users, but they're not documented. I just added the documentation for these settings.

Besides, if a custom logging path doesn't exist yet, the pr will try to create the corresponding folder.