### PR TITLE
Keep logging filename consistent in messages

### DIFF
--- a/scripts/toggle_logging.sh
+++ b/scripts/toggle_logging.sh
@@ -10,15 +10,11 @@ start_pipe_pane() {
 	local file=$(expand_tmux_format_path "${logging_full_filename}")
 	"$CURRENT_DIR/start_logging.sh" "${file}"
 	display_message "Started logging to ${logging_full_filename}"
-	# save logging file name to be displayed when logging stops
-	tmux set-option -g "@logging-full-filename" "$file"
 }
 
 stop_pipe_pane() {
 	tmux pipe-pane
 	display_message "Ended logging to $logging_full_filename"
-	# unset logging-full-filename
-	tmux set-option -gu "@logging-full-filename"
 }
 
 # returns a string unique to current pane
@@ -31,6 +27,13 @@ set_logging_variable() {
 	local value="$1"
 	local pane_unique_id="$(pane_unique_id)"
 	tmux set-option -gq "@${pane_unique_id}" "$value"
+
+	if [ "$1" == "logging" ]; then
+		local file=$(expand_tmux_format_path "${logging_full_filename}")
+		tmux set-option -g "@logging-full-filename" "$file"
+	elif [ "$1" == "not logging" ]; then
+		tmux set-option -gu "@logging-full-filename"
+	fi
 }
 
 # this function checks if logging is happening for the current pane

--- a/scripts/toggle_logging.sh
+++ b/scripts/toggle_logging.sh
@@ -10,11 +10,15 @@ start_pipe_pane() {
 	local file=$(expand_tmux_format_path "${logging_full_filename}")
 	"$CURRENT_DIR/start_logging.sh" "${file}"
 	display_message "Started logging to ${logging_full_filename}"
+	# save logging file name to be displayed when logging stops
+	tmux set-option -g "@logging-full-filename" "$file"
 }
 
 stop_pipe_pane() {
 	tmux pipe-pane
 	display_message "Ended logging to $logging_full_filename"
+	# unset logging-full-filename
+	tmux set-option -gu "@logging-full-filename"
 }
 
 # returns a string unique to current pane

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -30,7 +30,8 @@ default_logging_filename="tmux-${filename_suffix}"
 logging_filename=$(tmux show-option -gqv "@logging-filename")
 logging_filename=${logging_filename:-$default_logging_filename}
 
-logging_full_filename="${logging_path}/${logging_filename}"
+logging_full_filename=$(tmux show-option -gqv "@logging-full-filename")
+logging_full_filename=${logging_full_filename:-$logging_path/$logging_filename}
 
 # Screen capture options
 default_screen_capture_path="$HOME"


### PR DESCRIPTION
This pr saves expanded `$logging_full_filename` after logging starts. Then the script reloads the full filename when users stop the logging, which make the filename consistent with the filename generated at the time when logging started.

Otherwise, the filename is regenerated when users stop the logging. Although the the new filename is not used for logging, but it's displayed in the message. The different logging filenames may confuse users.

This pr fixes #36 .