### PR TITLE
Let start_logging be called directly.

### DIFF
--- a/scripts/start_logging.sh
+++ b/scripts/start_logging.sh
@@ -3,6 +3,17 @@
 # path to log file - global variable
 FILE="$1"
 
+# If called directly, read context and enable logging
+if [ ! "${FILE}" ] ; then
+	CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+	source "$CURRENT_DIR/variables.sh"
+	source "$CURRENT_DIR/shared.sh"
+	file=$(expand_tmux_format_path "${logging_full_filename}")
+	display_message "Started logging to ${logging_full_filename}"
+
+fi
+
 ansifilter_installed() {
 	type ansifilter >/dev/null 2>&1 || return 1
 }
@@ -18,12 +29,14 @@ pipe_pane_ansifilter() {
 pipe_pane_sed_osx() {
 	# Warning, very complex regex ahead.
 	# Some characters below might not be visible from github web view.
-	local ansi_codes_osx="(\[([0-9]{1,3}((;[0-9]{1,3})*)?)?[m|K]||]0;[^]+|[[:space:]]+$)"
+	local ansi_codes_osx="(\[([0-9]{1,3}((;[0-9]{1,3})*)?)?[m|K]|
+|]0;[^]+|[[:space:]]+$)"
 	tmux pipe-pane "exec cat - | sed -E \"s/$ansi_codes_osx//g\" >> $FILE"
 }
 
 pipe_pane_sed() {
-	local ansi_codes="(\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]|)"
+	local ansi_codes="(\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]|
+)"
 	tmux pipe-pane "exec cat - | sed -r 's/$ansi_codes//g' >> $FILE"
 }
 


### PR DESCRIPTION
Fixes https://github.com/tmux-plugins/tmux-logging/issues/31

Note that a cleaner solution may be to restructure the toggle/start scripts so that the block I added didn't need to replicate the context read that already exists in the toggle script.