### PR TITLE
Add screen output pipe command option

### DIFF
--- a/scripts/screen_capture.sh
+++ b/scripts/screen_capture.sh
@@ -8,7 +8,7 @@ source "$CURRENT_DIR/shared.sh"
 main() {
 	if supported_tmux_version_ok; then
 		local file=$(expand_tmux_format_path "${screen_capture_full_filename}")
-		tmux capture-pane -J -p > "${file}"
+		tmux capture-pane -J -p | $screen_capture_pipe_command  > "${file}"
 		remove_empty_lines_from_end_of_file "${file}"
 		display_message "Screen capture saved to ${file}"
 	fi

--- a/scripts/start_logging.sh
+++ b/scripts/start_logging.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source "$CURRENT_DIR/variables.sh"
+source "$CURRENT_DIR/shared.sh"
+
 # path to log file - global variable
 FILE="$1"
 
@@ -12,19 +17,19 @@ system_osx() {
 }
 
 pipe_pane_ansifilter() {
-	tmux pipe-pane "exec cat - | ansifilter >> $FILE"
+	tmux pipe-pane "exec cat - | ansifilter | $screen_capture_pipe_command >> $FILE"
 }
 
 pipe_pane_sed_osx() {
 	# Warning, very complex regex ahead.
 	# Some characters below might not be visible from github web view.
 	local ansi_codes_osx="(\[([0-9]{1,3}((;[0-9]{1,3})*)?)?[m|K]||]0;[^]+|[[:space:]]+$)"
-	tmux pipe-pane "exec cat - | sed -E \"s/$ansi_codes_osx//g\" >> $FILE"
+	tmux pipe-pane "exec cat - | sed -E \"s/$ansi_codes_osx//g\" | $screen_capture_pipe_command >> $FILE"
 }
 
 pipe_pane_sed() {
 	local ansi_codes="(\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]|)"
-	tmux pipe-pane "exec cat - | sed -r 's/$ansi_codes//g' >> $FILE"
+	tmux pipe-pane "exec cat - | sed -r 's/$ansi_codes//g' | $screen_capture_pipe_command >> $FILE"
 }
 
 start_pipe_pane() {

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -43,6 +43,10 @@ screen_capture_filename=${screen_capture_filename:-$default_screen_capture_filen
 
 screen_capture_full_filename="${screen_capture_path}/${screen_capture_filename}"
 
+default_screen_capture_pipe_command="cat"
+screen_capture_pipe_command=$(tmux show-option -gqv "@screen-capture-pipe-command")
+screen_capture_pipe_command=${screen_capture_pipe_command:-$default_screen_capture_pipe_command}
+
 # Save complete history options
 default_save_complete_history_path="$HOME"
 save_complete_history_path=$(tmux show-option -gqv "@save-complete-history-path")


### PR DESCRIPTION
Allows piping all pane saving through some command. Default is cat,
effectively a noop.

One example use case (how I plan to use this) is to pipe all output
through `ts`, prepending timestamps to captured output.

set via
```
set -g @screen-capture-pipe-command 'ts'
```