### PR TITLE
Allow log file names to be passed as argument to start logging.

### DIFF
--- a/scripts/toggle_logging.sh
+++ b/scripts/toggle_logging.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Log filename may be passed as an argument optionally.
+# If none passed, the new log file will be created per the configuration
+# guide.
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -7,9 +10,10 @@ source "$CURRENT_DIR/shared.sh"
 
 
 start_pipe_pane() {
-	local file=$(expand_tmux_format_path "${logging_full_filename}")
+	local fname=$(expand_tmux_format_path "${logging_full_filename}")
+	local file=${1:-$fname}
 	"$CURRENT_DIR/start_logging.sh" "${file}"
-	display_message "Started logging to ${logging_full_filename}"
+	display_message "Started logging to ${file}"
 }
 
 stop_pipe_pane() {
@@ -47,13 +51,14 @@ toggle_pipe_pane() {
 		stop_pipe_pane
 	else
 		set_logging_variable "logging"
-		start_pipe_pane
+		start_pipe_pane $1
 	fi
 }
 
 main() {
 	if supported_tmux_version_ok; then
-		toggle_pipe_pane
+		toggle_pipe_pane $1
 	fi
 }
-main
+# if argument is passed, treat it as the logfilename
+main $1


### PR DESCRIPTION
User may start logging by as below.
    send source\ ~/.tmux/plugins/tmux-logging/scripts/toggle_logging.sh ENTER\;   send start_pipe_pane\ ${HOME}/mylogfile ENTER \;