### PR TITLE
Add "notes" to keybindings

### DIFF
--- a/logging.tmux
+++ b/logging.tmux
@@ -7,10 +7,10 @@ source "$CURRENT_DIR/scripts/shared.sh"
 
 
 main() {
-	tmux bind-key "$logging_key" run-shell "$CURRENT_DIR/scripts/toggle_logging.sh"
-	tmux bind-key "$pane_screen_capture_key" run-shell "$CURRENT_DIR/scripts/screen_capture.sh"
-	tmux bind-key "$save_complete_history_key" run-shell "$CURRENT_DIR/scripts/save_complete_history.sh"
-	tmux bind-key "$clear_history_key" run-shell "$CURRENT_DIR/scripts/clear_history.sh"
+	tmux bind-key -N "Begin logging current pane" "$logging_key" run-shell "$CURRENT_DIR/scripts/toggle_logging.sh"
+	tmux bind-key -N "Pane screenshot" "$pane_screen_capture_key" run-shell "$CURRENT_DIR/scripts/screen_capture.sh"
+	tmux bind-key -N "Save pane complete history" "$save_complete_history_key" run-shell "$CURRENT_DIR/scripts/save_complete_history.sh"
+	tmux bind-key -N "Clear pane history" "$clear_history_key" run-shell "$CURRENT_DIR/scripts/clear_history.sh"
 }
 
 main


### PR DESCRIPTION
By default, tmux binds PREFIX+~ to tmux command "list-keys -N", which display a relatively pretty listing of tmux keybindings, but only for those keybindings that were defined with a descriptive "note". This PR adds those notes for "tmux-logging" commands.