### PR TITLE
Add info for custom additional log paths

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,3 +1,8 @@
 # Custom configuration
 
-The default logging path is `$HOME` To change that, add `set -g @logging-path "path"` to `.tmux.conf` file 
+The default logging path is `$HOME` but can be changed per log type.  
+
+To change the logging paths, add the following lines to your `.tmux.conf` file:  
+* For continuous pane logs: `set -g @logging-path "path"`  
+* For screen captures: `set -g @screen-capture-path "path"`  
+* For complete pane history: `set -g @save-complete-history-path "path"`


### PR DESCRIPTION
Adds info for the required additions to .tmux.conf to change the log path for coninuous pane logs and complete pane history logs to configuration.md.