### PR TITLE
Remove 'cat -' from logging pipe-pane command

### DIFF
--- a/scripts/start_logging.sh
+++ b/scripts/start_logging.sh
@@ -12,19 +12,19 @@ system_osx() {
 }
 
 pipe_pane_ansifilter() {
-	tmux pipe-pane "exec cat - | ansifilter >> $FILE"
+	tmux pipe-pane "exec ansifilter >> $FILE"
 }
 
 pipe_pane_sed_osx() {
 	# Warning, very complex regex ahead.
 	# Some characters below might not be visible from github web view.
 	local ansi_codes_osx="(\[([0-9]{1,3}((;[0-9]{1,3})*)?)?[m|K]||]0;[^]+|[[:space:]]+$)"
-	tmux pipe-pane "exec cat - | sed -E \"s/$ansi_codes_osx//g\" >> $FILE"
+	tmux pipe-pane "exec sed -E \"s/$ansi_codes_osx//g\" >> $FILE"
 }
 
 pipe_pane_sed() {
 	local ansi_codes="(\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]|)"
-	tmux pipe-pane "exec cat - | sed -r 's/$ansi_codes//g' >> $FILE"
+	tmux pipe-pane "exec sed -r 's/$ansi_codes//g' >> $FILE"
 }
 
 start_pipe_pane() {


### PR DESCRIPTION
The cat is unnecessary since tmux can pipe directly to ansifilter/sed (or any other program that reads from stdin).  If ansifilter/sed weren't being used then cat would be necessary, because pipe-pane needs a command to send the output to.