### PR TITLE
Ensure correct filename is displayed in Start/Stop messages

### DIFF
--- a/scripts/toggle_logging.sh
+++ b/scripts/toggle_logging.sh
@@ -10,16 +10,22 @@ start_pipe_pane() {
 	local file=$(expand_tmux_format_path "${logging_full_filename}")
 	"$CURRENT_DIR/start_logging.sh" "${file}"
 	display_message "Started logging to ${file}"
+	set_logging_variable "logging"
 }
 
 stop_pipe_pane() {
 	tmux pipe-pane
 	display_message "Ended logging to $logging_full_filename"
+	unset_logging_variable
 }
 
 # saving 'logging' 'not logging' status in a variable unique to pane
 set_logging_variable() {
 	tmux set-option -pq @logging-variable "$1"
+}
+
+unset_logging_variable() {
+	tmux set-option -pu @logging-variable
 }
 
 get_logging_variable() {
@@ -28,7 +34,7 @@ get_logging_variable() {
 
 # this function checks if logging is happening for the current pane
 is_logging() {
-	if [ "$(get_logging_variable)" == "logging" ]; then
+	if [ -n "$(get_logging_variable)" ]; then
 		return 0
 	else
 		return 1
@@ -38,10 +44,8 @@ is_logging() {
 # starts/stop logging
 toggle_pipe_pane() {
 	if is_logging; then
-		set_logging_variable "not logging"
 		stop_pipe_pane
 	else
-		set_logging_variable "logging"
 		start_pipe_pane
 	fi
 }

--- a/scripts/toggle_logging.sh
+++ b/scripts/toggle_logging.sh
@@ -10,12 +10,12 @@ start_pipe_pane() {
 	local file=$(expand_tmux_format_path "${logging_full_filename}")
 	"$CURRENT_DIR/start_logging.sh" "${file}"
 	display_message "Started logging to ${file}"
-	set_logging_variable "logging"
+	set_logging_variable "${file}"
 }
 
 stop_pipe_pane() {
 	tmux pipe-pane
-	display_message "Ended logging to $logging_full_filename"
+	display_message "Ended logging to $(get_logging_variable)"
 	unset_logging_variable
 }
 

--- a/scripts/toggle_logging.sh
+++ b/scripts/toggle_logging.sh
@@ -29,11 +29,15 @@ set_logging_variable() {
 	tmux set-option -gq "@${pane_unique_id}" "$value"
 }
 
-# this function checks if logging is happening for the current pane
-is_logging() {
+get_logging_variable() {
 	local pane_unique_id="$(pane_unique_id)"
 	local current_pane_logging="$(get_tmux_option "@${pane_unique_id}" "not logging")"
-	if [ "$current_pane_logging" == "logging" ]; then
+	echo $current_pane_logging
+}
+
+# this function checks if logging is happening for the current pane
+is_logging() {
+	if [ "$(get_logging_variable)" == "logging" ]; then
 		return 0
 	else
 		return 1

--- a/scripts/toggle_logging.sh
+++ b/scripts/toggle_logging.sh
@@ -17,22 +17,13 @@ stop_pipe_pane() {
 	display_message "Ended logging to $logging_full_filename"
 }
 
-# returns a string unique to current pane
-pane_unique_id() {
-	tmux display-message -p "#{session_name}_#{window_index}_#{pane_index}"
-}
-
 # saving 'logging' 'not logging' status in a variable unique to pane
 set_logging_variable() {
-	local value="$1"
-	local pane_unique_id="$(pane_unique_id)"
-	tmux set-option -gq "@${pane_unique_id}" "$value"
+	tmux set-option -pq @logging-variable "$1"
 }
 
 get_logging_variable() {
-	local pane_unique_id="$(pane_unique_id)"
-	local current_pane_logging="$(get_tmux_option "@${pane_unique_id}" "not logging")"
-	echo $current_pane_logging
+	tmux show-option -pqv @logging-variable
 }
 
 # this function checks if logging is happening for the current pane

--- a/scripts/toggle_logging.sh
+++ b/scripts/toggle_logging.sh
@@ -10,31 +10,30 @@ start_pipe_pane() {
 	local file=$(expand_tmux_format_path "${logging_full_filename}")
 	"$CURRENT_DIR/start_logging.sh" "${file}"
 	display_message "Started logging to ${file}"
-	set_logging_variable "${file}"
+	set_active_logging_filename "${file}"
 }
 
 stop_pipe_pane() {
 	tmux pipe-pane
-	display_message "Ended logging to $(get_logging_variable)"
-	unset_logging_variable
+	display_message "Ended logging to $(get_active_logging_filename)"
+	unset_active_logging_filename
 }
 
-# saving 'logging' 'not logging' status in a variable unique to pane
-set_logging_variable() {
-	tmux set-option -pq @logging-variable "$1"
+set_active_logging_filename() {
+	tmux set-option -pq @active-logging-filename "$1"
 }
 
-unset_logging_variable() {
-	tmux set-option -pu @logging-variable
+unset_active_logging_filename() {
+	tmux set-option -pu @active-logging-filename
 }
 
-get_logging_variable() {
-	tmux show-option -pqv @logging-variable
+get_active_logging_filename() {
+	tmux show-option -pqv @active-logging-filename
 }
 
 # this function checks if logging is happening for the current pane
 is_logging() {
-	if [ -n "$(get_logging_variable)" ]; then
+	if [ -n "$(get_active_logging_filename)" ]; then
 		return 0
 	else
 		return 1

--- a/scripts/toggle_logging.sh
+++ b/scripts/toggle_logging.sh
@@ -9,7 +9,7 @@ source "$CURRENT_DIR/shared.sh"
 start_pipe_pane() {
 	local file=$(expand_tmux_format_path "${logging_full_filename}")
 	"$CURRENT_DIR/start_logging.sh" "${file}"
-	display_message "Started logging to ${logging_full_filename}"
+	display_message "Started logging to ${file}"
 }
 
 stop_pipe_pane() {


### PR DESCRIPTION
When starting logging it was possible for the filename displayed to be different than the actual filename used (though probably at most off by 1 second).  More importantly, when stopping logging the filename displayed would be constructed at the time that logging was stopped, so would almost never be correct.  This PR fixes both by repurposing the pane-specific `logging_variable` to hold the filename being logged to.