### PR TITLE
Simplify display_message

### DIFF
--- a/scripts/shared.sh
+++ b/scripts/shared.sh
@@ -20,17 +20,7 @@ display_message() {
 		local display_duration="5000"
 	fi
 
-	# saves user-set 'display-time' option
-	local saved_display_time=$(get_tmux_option "display-time" "750")
-
-	# sets message display time to 5 seconds
-	tmux set-option -gq display-time "$display_duration"
-
-	# displays message
-	tmux display-message "$message"
-
-	# restores original 'display-time' value
-	tmux set-option -gq display-time "$saved_display_time"
+	tmux display-message -d $display_duration "$message"
 }
 
 # simplest solution, taken from here: http://unix.stackexchange.com/a/81689

--- a/scripts/shared.sh
+++ b/scripts/shared.sh
@@ -9,18 +9,8 @@ get_tmux_option() {
 	fi
 }
 
-# Ensures a message is displayed for 5 seconds in tmux prompt
 display_message() {
-	local message=$1
-
-	# display_duration defaults to 5 seconds, if not passed as an argument
-	if [ "$#" -eq 2 ]; then
-		local display_duration=$2
-	else
-		local display_duration="5000"
-	fi
-
-	tmux display-message -d $display_duration "$message"
+	tmux display-message "$1"
 }
 
 # simplest solution, taken from here: http://unix.stackexchange.com/a/81689


### PR DESCRIPTION
- No scripts were passing the optional second parameter, so it would always use 5 seconds as the display time.
- If we are going to continue to force the message to be displayed for 5 seconds then it would be better to make it apply to only this particular message by using the `-d` option rather than overriding `display-time`.
- It might be better to respect the user's chosen `display-time`.